### PR TITLE
Specifying Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "grunt.js",
   "engines": {
-    "node": "*"
+    "node": ">=0.8"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Currently the node version is specified as all in package.json, however "path.sep" is used in multiple places throughout the task. "sep" was added in version 0.7.9(unstable), 0.8 being the next stable release.
