### PR TITLE
updating to work with grunt v0.4.0rc5.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-v0.4.0:
-  data: 2012-12-xx
+v0.4.0rc5:
+  date: 2013-01-14
   changes:
+    - Updating to work with grunt v0.4.0rc5.
     - Conversion to grunt v0.4 conventions.
     - Replace basePath with cwd.
     - Empty directory support.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,42 +40,23 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     copy: {
       main: {
-        options: {
-          cwd: 'test/fixtures'
-        },
-        files: {
-          'tmp/copy_test_files/': ['*.*'],
-          'tmp/copy_test_mix/': ['**'],
-          'tmp/copy_test_v<%= test_vars.version %>/': ['<%= test_vars.match %>']
-        }
+        files: [
+          {expand: true, cwd: 'test/fixtures', src: ['*.*'], dest: 'tmp/copy_test_files/'},
+          {expand: true, cwd: 'test/fixtures', src: ['**'], dest: 'tmp/copy_test_mix/'},
+          {expand: true, cwd: 'test/fixtures', src: ['<%= test_vars.match %>'], dest: 'tmp/copy_test_v<%= test_vars.version %>/'}
+        ]
       },
 
       flatten: {
-        options: {
-          flatten: true
-        },
-        files: {
-          'tmp/copy_test_flatten/': ['test/fixtures/**']
-        }
-      },
-
-      minimatch: {
-        options: {
-          cwd: 'test/fixtures',
-          excludeEmpty: true,
-          minimatch: {
-            dot: true
-          }
-        },
-        files: {
-          'tmp/copy_minimatch/': ['*']
-        }
+        files: [
+          {expand: true, flatten: true, filter: 'isFile', src: ['test/fixtures/**'], dest: 'tmp/copy_test_flatten/'}
+        ]
       },
 
       single: {
-        files: {
-          'tmp/single.js': ['test/fixtures/test.js']
-        }
+        files: [
+          {src: ['test/fixtures/test.js'], dest: 'tmp/single.js'}
+        ]
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -21,55 +21,9 @@ _This task is a [multi task][] so any targets, files and options should be speci
 [multi task]: https://github.com/gruntjs/grunt/wiki/Configuring-tasks
 
 
+_Version `0.4.x` of this plugin is compatible with Grunt `0.4.x`. Version `0.3.x` of this plugin is compatible with Grunt `0.3.x`._
+
 ### Options
-
-#### cwd
-Type: `String`
-
-This option sets the current working directory for use with the minimatch and copy process. This helps translate paths when copied so that the destination stucture matches the source structure exactly. Without a `cwd` set, all paths are relative to the gruntfile directory which can cause extra depth to be added to your copied structure when it may not be desired.
-
-When copying to a directory you must add a trailing slash to the destination due to added support of single file copy.
-
-```js
-copy: {
-  target: {
-    options: {
-      cwd: 'path/to/sources'
-    },
-    files: {
-      'tmp/test/': ['*', 'sub1/*']
-    }
-  }
-}
-```
-
-#### excludeEmpty
-Type: `Boolean`
-Default: false
-
-This option excludes empty folders from being copied to the destination directory.
-
-#### flatten
-Type: `Boolean`
-Default: false
-
-This option performs a flat copy that dumps all the files into the root of the destination directory, overwriting files if they exist.
-
-#### processName
-Type: `Function`
-
-This option accepts a function that adjusts the filename of the copied file. Function is passed filename and should return a string.
-
-```js
-options: {
-  processName: function(filename) {
-    if (filename == "test.jpg") {
-      filename = "newname.jpg";
-    }
-    return filename;
-  }
-}
-```
 
 #### processContent
 Type: `Function`
@@ -81,23 +35,17 @@ Type: `String`
 
 This option is passed to `grunt.file.copy` as an advanced way to control which file contents are processed.
 
-#### minimatch
-Type: `Object`
-
-These options will be forwarded on to expandFiles, as referenced in the [minimatch options section](https://github.com/isaacs/minimatch/#options)
-
 ### Usage Examples
 
 ```js
 copy: {
-  dist: {
-    files: {
-      "path/to/directory/": "path/to/source/*", // includes files in dir
-      "path/to/directory/": "path/to/source/**", // includes files in dir and subdirs
-      "path/to/project-<%= pkg.version %>/": "path/to/source/**", // variables in destination
-      "path/to/directory/": ["path/to/sources/*.js", "path/to/more/*.js"], // include JS files in two diff dirs
-      "path/to/filename.ext": "path/to/source.ext"
-    }
+  main: {
+    files: [
+      {src: ['path/*'], dest: 'dest/', filter: 'isFile'}, // includes files in path
+      {src: ['path/**'], dest: 'dest/'}, // includes files in path and its subdirs
+      {expand: true, cwd: 'path/', src: ['**'], dest: 'dest/'}, // makes all src relative to cwd
+      {expand: true, flatten: true, src: ['path/**'], dest: 'dest/', filter: 'isFile'} // flattens results to a single level
+    ]
   }
 }
 ```
@@ -105,7 +53,7 @@ copy: {
 
 ## Release History
 
- * 2012-11-29   v0.4.0   Conversion to grunt v0.4 conventions. Replace basePath with cwd. Empty directory support.
+ * 2013-01-13   v0.4.0rc5   Updating to work with grunt v0.4.0rc5. Conversion to grunt v0.4 conventions. Replace basePath with cwd. Empty directory support.
  * 2012-10-17   v0.3.2   Pass copyOptions on single file copy.
  * 2012-10-11   v0.3.1   Rename grunt-contrib-lib dep to grunt-lib-contrib.
  * 2012-09-23   v0.3.0   General cleanup and consolidation. Global options depreciated.
@@ -118,4 +66,4 @@ copy: {
 
 Task submitted by [Chris Talkington](http://christalkington.com/)
 
-*This file was generated on Thu Nov 29 2012 20:23:02.*
+*This file was generated on Wed Jan 16 2013 00:16:55.*

--- a/docs/copy-examples.md
+++ b/docs/copy-examples.md
@@ -2,14 +2,13 @@
 
 ```js
 copy: {
-  dist: {
-    files: {
-      "path/to/directory/": "path/to/source/*", // includes files in dir
-      "path/to/directory/": "path/to/source/**", // includes files in dir and subdirs
-      "path/to/project-<%= pkg.version %>/": "path/to/source/**", // variables in destination
-      "path/to/directory/": ["path/to/sources/*.js", "path/to/more/*.js"], // include JS files in two diff dirs
-      "path/to/filename.ext": "path/to/source.ext"
-    }
+  main: {
+    files: [
+      {src: ['path/*'], dest: 'dest/', filter: 'isFile'}, // includes files in path
+      {src: ['path/**'], dest: 'dest/'}, // includes files in path and its subdirs
+      {expand: true, cwd: 'path/', src: ['**'], dest: 'dest/'}, // makes all src relative to cwd
+      {expand: true, flatten: true, src: ['path/**'], dest: 'dest/', filter: 'isFile'} // flattens results to a single level
+    ]
   }
 }
 ```

--- a/docs/copy-options.md
+++ b/docs/copy-options.md
@@ -1,53 +1,5 @@
 # Options
 
-## cwd
-Type: `String`
-
-This option sets the current working directory for use with the minimatch and copy process. This helps translate paths when copied so that the destination stucture matches the source structure exactly. Without a `cwd` set, all paths are relative to the gruntfile directory which can cause extra depth to be added to your copied structure when it may not be desired.
-
-When copying to a directory you must add a trailing slash to the destination due to added support of single file copy.
-
-```js
-copy: {
-  target: {
-    options: {
-      cwd: 'path/to/sources'
-    },
-    files: {
-      'tmp/test/': ['*', 'sub1/*']
-    }
-  }
-}
-```
-
-## excludeEmpty
-Type: `Boolean`
-Default: false
-
-This option excludes empty folders from being copied to the destination directory.
-
-## flatten
-Type: `Boolean`
-Default: false
-
-This option performs a flat copy that dumps all the files into the root of the destination directory, overwriting files if they exist.
-
-## processName
-Type: `Function`
-
-This option accepts a function that adjusts the filename of the copied file. Function is passed filename and should return a string.
-
-```js
-options: {
-  processName: function(filename) {
-    if (filename == "test.jpg") {
-      filename = "newname.jpg";
-    }
-    return filename;
-  }
-}
-```
-
 ## processContent
 Type: `Function`
 
@@ -57,8 +9,3 @@ This option is passed to `grunt.file.copy` as an advanced way to control the fil
 Type: `String`
 
 This option is passed to `grunt.file.copy` as an advanced way to control which file contents are processed.
-
-## minimatch
-Type: `Object`
-
-These options will be forwarded on to expandFiles, as referenced in the [minimatch options section](https://github.com/isaacs/minimatch/#options)

--- a/docs/copy-overview.md
+++ b/docs/copy-overview.md
@@ -1,1 +1,3 @@
 {%= s.multi_task %}
+
+_Version `0.4.x` of this plugin is compatible with Grunt `0.4.x`. Version `0.3.x` of this plugin is compatible with Grunt `0.3.x`._

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-copy",
   "description": "Copy files and folders.",
-  "version": "0.4.0a",
+  "version": "0.4.0rc5",
   "homepage": "https://github.com/gruntjs/grunt-contrib-copy",
   "author": {
     "name": "Grunt Team",
@@ -31,11 +31,11 @@
     "grunt-lib-contrib": "~0.4.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.0",
-    "grunt-contrib-nodeunit": "~0.1.0",
-    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~0.1.1rc5",
+    "grunt-contrib-nodeunit": "~0.1.2rc5",
+    "grunt-contrib-clean": "~0.4.0rc5",
     "grunt-contrib-internal": "~0.1.1",
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0rc5"
   },
   "keywords": [
     "gruntplugin"

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -21,6 +21,7 @@ exports.copy = {
 
     test.done();
   },
+
   flatten: function(test) {
     'use strict';
 
@@ -32,17 +33,7 @@ exports.copy = {
 
     test.done();
   },
-  minimatch: function(test) {
-    'use strict';
 
-    test.expect(1);
-
-    var actual = fs.readdirSync('tmp/copy_minimatch').sort();
-    var expected = fs.readdirSync('test/expected/copy_minimatch').sort();
-    test.deepEqual(expected, actual, 'should allow for minimatch dot option');
-
-    test.done();
-  },
   single: function(test) {
     'use strict';
 

--- a/test/expected/copy_minimatch/.hidden
+++ b/test/expected/copy_minimatch/.hidden
@@ -1,1 +1,0 @@
-#This is a hidden file!!!

--- a/test/expected/copy_minimatch/test.js
+++ b/test/expected/copy_minimatch/test.js
@@ -1,1 +1,0 @@
-$(document).ready(function(){});

--- a/test/expected/copy_minimatch/test2.js
+++ b/test/expected/copy_minimatch/test2.js
@@ -1,1 +1,0 @@
-console.log('hello');


### PR DESCRIPTION
this should get us to rc5 compat.
### Changes
- [x] remove `cwd`, `flatten`, `minimatch`, `processName` options; can be controlled by grunt multi-task config modifiers now.
- [x] new examples and docs.
- [ ] new tests that check integration with grunt multi-task config modifiers. (ie cwd, flatten, expand, etc)
### Testing/Install Now

``` shell
npm install ctalkington/grunt-contrib-copy#patch4 // shorthand node >= v0.8.17
npm install https://github.com/ctalkington/grunt-contrib-copy/archive/patch4.tar.gz
```
