### PR TITLE
Updating log messages to verbose

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -42,10 +42,10 @@ module.exports = function(grunt) {
         }
 
         if (grunt.file.isDir(src)) {
-          grunt.log.writeln('Creating ' + dest.cyan);
+          grunt.verbose.writeln('Creating ' + dest.cyan);
           grunt.file.mkdir(dest);
         } else {
-          grunt.log.writeln('Copying ' + src.cyan + ' -> ' + dest.cyan);
+          grunt.verbose.writeln('Copying ' + src.cyan + ' -> ' + dest.cyan);
           grunt.file.copy(src, dest, copyOptions);
         }
       });


### PR DESCRIPTION
This is just updating the grunt.log.writeln to grunt.verbose.writeln to try to reduce the amount of output when copying large directories.
