### PR TITLE
provide a quiet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ copy: {
 }
 ```
 
+#### quiet
+
+Type: `boolean`
+
+This option supresses output to STDOUT. This is set to false by default.
+
+```js
+copy: {
+  main: {
+    options: {
+      quiet: true
+    },
+    files: [
+      {
+        expand: true,
+        cwd: 'src',
+        src: ['**',],
+        dest: 'build/'
+      }
+    ]
+  }
+}
+```
 
 ## Release History
 

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -17,12 +17,14 @@ module.exports = function(grunt) {
 
     var options = this.options({
       processContent: false,
-      processContentExclude: []
+      processContentExclude: [],
+      quiet: false
     });
 
     var copyOptions = {
       process: options.processContent,
-      noProcess: options.processContentExclude
+      noProcess: options.processContentExclude,
+      quiet: options.quiet
     };
 
     grunt.verbose.writeflags(options, 'Options');
@@ -41,10 +43,14 @@ module.exports = function(grunt) {
         }
 
         if (grunt.file.isDir(src)) {
-          grunt.log.writeln('Creating ' + dest.cyan);
+          if (options.quiet === false) {
+            grunt.log.writeln('Creating ' + dest.cyan);
+          }
           grunt.file.mkdir(dest);
         } else {
-          grunt.log.writeln('Copying ' + src.cyan + ' -> ' + dest.cyan);
+          if (options.quiet === false) {
+            grunt.log.writeln('Copying ' + src.cyan + ' -> ' + dest.cyan);
+          }
           grunt.file.copy(src, dest, copyOptions);
         }
       });


### PR DESCRIPTION
This pull request provides a quiet option to suppress output to STDOUT. It can be enabled as follows. 

``` js
copy: {
  main: {
    options: {
      quiet: true
    },
    files: [
      {
        expand: true,
        cwd: 'src',
        src: ['**',],
        dest: 'build/'
      }
    ]
  }
}
```
