### PR TITLE
Add hardLink option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Type: `String`
 
 This option is passed to `grunt.file.copy` as an advanced way to control which file contents are processed.
 
+#### hardLink
+Type: `Boolean`
+
+This option will hard link files instead of copying them.  If `processContent` applies to a file then the file will still be copied. On Windows this option will not apply.
+
 ### Usage Examples
 
 ```js


### PR DESCRIPTION
This adds a `hardLink` option, so you can create links instead of copies of files.

I am using a grunt task for building a source tree, for development as well as production, and the lag when using `grunt watch` catches me sometimes when I edit and test/reload before the files are rebuilt.  With hard links, at least for those files where it is applicable, there will be no lag.

This is more of a start-the-discussion pull request, as I'm sure there are issues with the implementation.  Specifically I'm guessing that using the `fs` module directly might be verboten, and/or that this functionality might more appropriately exist in `grunt.file.copy` directly (especially since it interacts with `processContent`).

Also I didn't understand the the tests – I see the assertions but not where the "work" is actually done that creates the output that is asserted against?
