### PR TITLE
If an encoding is specified, overwrite grunt.file.defaultEncoding.

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -16,11 +16,13 @@ module.exports = function(grunt) {
     var kindOf = grunt.util.kindOf;
 
     var options = this.options({
+      encoding: grunt.file.defaultEncoding,
       processContent: false,
       processContentExclude: []
     });
-
+    
     var copyOptions = {
+      encoding: options.encoding,
       process: options.processContent,
       noProcess: options.processContentExclude
     };


### PR DESCRIPTION
``` javascript
/*global module:false*/
module.exports = function (grunt) {
    grunt.file.defaultEncoding = 'gbk';

    grunt.initConfig({
        copy: {
            'all': {
                options: {
                    encoding: 'utf8'
                },

                files: [
                    {
                        expand: true,
                        cwd: 'template/',
                        src: ['*.tpl', 'aladdin/**', 'config/**'],
                        dest: '../build/template/'
                    }
                ]
            }
        }
    });
};
```
