### PR TITLE
Added 'forceOverwrite' option

### DIFF
--- a/docs/copy-options.md
+++ b/docs/copy-options.md
@@ -9,3 +9,10 @@ This option is passed to `grunt.file.copy` as an advanced way to control the fil
 Type: `String`
 
 This option is passed to `grunt.file.copy` as an advanced way to control which file contents are processed.
+
+
+## forceOverwrite
+Type: `Boolean`
+
+This option forces to overwrite files while copying regardless of their existence and attributes in destination.
+Particulary it allow to overwrite read-only files (by default copying will fail).

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
 
     var options = this.options({
       processContent: false,
-      processContentExclude: []
+      processContentExclude: [],
+      forceOverwrite: false
     });
 
     var copyOptions = {
@@ -50,6 +51,9 @@ module.exports = function(grunt) {
           tally.dirs++;
         } else {
           grunt.verbose.writeln('Copying ' + src.cyan + ' -> ' + dest.cyan);
+          if (options.forceOverwrite && grunt.file.exists(dest)) {
+              grunt.file.delete(dest, {force: true});
+          }
           grunt.file.copy(src, dest, copyOptions);
           tally.files++;
         }


### PR DESCRIPTION
The option 'forceOverwrite' forces to overwrite files while copying regardless of their existence and attributes in destination.

Fixes #95
