### PR TITLE
Fixes pluralization for CLI (Copied 1 _file_)

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
     }
 
     if (tally.files) {
-      grunt.log.write((tally.dirs ? ', copied ' : 'Copied ') + tally.files.toString().cyan + ' files');
+      grunt.log.write((tally.dirs ? ', copied ' : 'Copied ') + tally.files.toString().cyan + (tally.files === 1 ? ' file' : ' files'));
     }
 
     grunt.log.writeln();


### PR DESCRIPTION
Relatively trivial text update to print 'Copied 1 file' instead of 'Copied 1 files'.
