### PR TITLE
Adding a filter function for the copy operation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,16 @@ module.exports = function(grunt) {
         src: ['test/fixtures/test2.js'],
         dest: 'tmp/mode.js',
       },
+      filter_function: {
+         src: [ 'test/fixtures/test.js'], 
+         dest: 'tmp/copy_filter_function/', 
+         filter: function( old_dest ){
+           var prefix_dest = old_dest.substring( 0, old_dest.indexOf('copy_filter_function') + 'copy_filter_function'.length );
+           var postfix_dest = old_dest.substring( old_dest.indexOf( 'test.js' ) );
+           var new_dest = prefix_dest+'/inserted/'+postfix_dest;
+           return new_dest;
+         }
+      }
     },
 
     // Unit tests.

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -39,13 +39,12 @@ module.exports = function(grunt) {
     };
 
     this.files.forEach(function(filePair) {
-      var filterFunction = filePair.filter ? filePair.filter : function(_dest){return _dest;};
       isExpandedPair = filePair.orig.expand || false;
 
       filePair.src.forEach(function(src) {
         if (detectDestType(filePair.dest) === 'directory') {
           dest = (isExpandedPair) ? filePair.dest : unixifyPath(path.join(filePair.dest, src));
-            dest = filePair.dest + filterFunction( src );
+          dest = filePair.filter ? filePair.filter( dest ) : dest;
         } else {
           dest = filePair.dest;
         }

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -54,5 +54,17 @@ exports.copy = {
     test.equal(fs.lstatSync('tmp/mode.js').mode.toString(8).slice(-3), '444');
 
     test.done();
+  },
+  filter_function: function(test) {
+    'use strict';
+
+    test.expect(1);
+
+    var actual = fs.readdirSync('tmp/copy_test_flatten').sort();
+    var expected = fs.readdirSync('test/expected/copy_test_flatten').sort();
+    test.deepEqual(expected, actual, 'should create a flat structure');
+
+    test.done();
   }
+
 };


### PR DESCRIPTION
This change introduces the possibility of adding a filter function to the copy operation, with the addition of a `filter` key:

```
filter_function: {
  src: [ 'some/source/file.js'], 
  dest: 'our/destination/directory/', 
  filter: function( old_dest ){
    return 'another/path/to/put/atop/+old_dest;
  }
},
```

This means that the user is able to control the destination path in more detail, for instance when certain elements of the src path needs to be excluded, or certain files needs to be filtered from the copy operation.

This possibly also addresses https://github.com/gruntjs/grunt-contrib-copy/issues/82
