### PR TITLE
diffCopy task for comparing files before copying

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,7 +91,8 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'copy', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'copy', 'nodeunit', 'test:diffCopy']);
+  grunt.registerTask('test:diffCopy', ['clean', 'diffCopy', 'diffCopy', 'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-copy v0.5.0 [![Build Status](https://travis-ci.org/gruntjs/grunt-contrib-copy.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-copy)
+# grunt-contrib-copy v0.5.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-copy.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-copy)
 
 > Copy files and folders.
 
@@ -229,4 +229,4 @@ Aborted due to warnings.
 
 Task submitted by [Chris Talkington](http://christalkington.com/)
 
-*This file was generated on Mon Dec 23 2013 20:21:57.*
+*This file was generated on Fri May 02 2014 00:44:23.*

--- a/tasks/diffCopy.js
+++ b/tasks/diffCopy.js
@@ -1,0 +1,109 @@
+/*
+ * grunt-contrib-copy
+ * http://gruntjs.com/
+ *
+ * Copyright (c) 2014 Chris Talkington, contributors
+ * Licensed under the MIT license.
+ * https://github.com/gruntjs/grunt-contrib-copy/blob/master/LICENSE-MIT
+ */
+
+module.exports = function(grunt) {
+  'use strict';
+
+
+  // store original values in private variable.
+  var originalConfig;
+  var configKey;
+
+  grunt.registerTask('diffCopy', 'Copy only if changed.', function() {
+    var taskChain = grunt.util._.first(this.args);
+    var files = checkCopies(taskChain);
+
+    if( !taskChain ) {
+      grunt.task.run(grunt.util._.map(grunt.util._.keys(grunt.config('copy')), function(target) {
+        return 'diffCopy:'+target;
+      }));
+      return;
+    }
+
+    configKey = 'copy.'+taskChain+'.files';
+    originalConfig = grunt.config(configKey);
+
+
+    if( files && files.length ) {
+      grunt.config(configKey, files);
+      grunt.task.run('copy:'+taskChain);
+      grunt.task.run('diffCopy:__postrun');
+    } else {
+      grunt.log.warn('No files changed; copy:%s not run.', taskChain);
+    }
+
+  });
+
+  // reset config to original values.
+  grunt.registerTask('diffCopy:__postrun', function() {
+    grunt.config(configKey, originalConfig);
+  });
+
+  function checkCopies(target) {
+    var confPath = grunt.util._.compact(['copy', target]).join('.');
+    grunt.config.requires(confPath);
+    var conf = grunt.config(confPath);
+
+    var srcDestPairs = conf && grunt.task.normalizeMultiTaskFiles(conf);
+
+    function compare(src, dest) {
+      var newer = grunt.file.read(src);
+      var older = grunt.file.read(dest);
+
+      var test = (newer !== older);
+
+      return test;
+    }
+
+
+    srcDestPairs = grunt.util._.filter(srcDestPairs, function(pair) {
+      var src = pair && pair.src && grunt.util._.first(pair.src);
+      var dest = pair && pair.dest;
+
+      var srcIsFile = src && grunt.file.isFile(src);
+      var srcIsDir = src && grunt.file.isDir(src);
+      var srcExists = src && grunt.file.exists(src);
+
+      var srcIsRootDir = false;
+
+      var wildCardRegex = /\/[\*]{1,2}$/;
+
+      if ( srcIsDir && pair.orig && pair.orig.expand ) {
+        if( src === pair.orig.cwd ) {
+          srcIsRootDir = true;
+        } else if ( src === grunt.util._.first(pair.orig.src).replace(wildCardRegex, '')) {
+          srcIsRootDir = true; 
+        }
+      }
+
+      if ( srcIsRootDir ) {
+        srcExists = false;
+      }
+
+      var destIsFile = dest && grunt.file.isFile(dest);
+      var destExists = dest && grunt.file.exists(dest);
+
+      var bothFiles = srcIsFile && destIsFile;
+      var srcIsFresh = srcExists && !destExists;
+
+      if( bothFiles ) {
+        return compare(src, dest);
+      } else if ( srcIsFresh ) {
+        return true;
+      }
+    });
+
+    if( srcDestPairs.length > 0 ) {
+      grunt.log.ok('Changed files: %s', grunt.util._.pluck(srcDestPairs, 'dest').join(' '));
+    }
+
+    return srcDestPairs;
+
+  }
+};


### PR DESCRIPTION
Hello.

This is a task I wrote for personal use, and I found it comes very much in handy when combined with the excellent [grunt-newer](https://www.npmjs.org/package/grunt-newer). I'm not sure if the contrib plugin is the best place for this task, but since it's so dependent on the `copy` multitask and offers no real standalone functionality, I thought I'd offer it up as a Pull Request.

Any ideas on fleshing out the tests for this task? Right now just piggybacking on existing copy tests, with manual check of log output to see if the second pass is a no-op as expected.

Thanks for the wonderful plugin!
