### PR TITLE
Note about cwd and expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ To process all files in a directory, the `process` function is used in exactly t
 
 NOTE: If `process` is not working, be aware it was called `processContent` in v0.4.1 and earlier.
 
-NOTE: If you plan to use the `cwd` option you need to set `expand: true` as well. For more info prease referer to the Grunt docs, http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically.
+NOTE: If you plan to use the `cwd` option you need to set `expand: true` as well. For more info please referer to the Grunt docs, http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically.
 
 ##### Troubleshooting
 


### PR DESCRIPTION
Since the connection between `cwd` and `expand` was not obvious to me. Because I don't know Grunts file objects all that well, and it would have saved my headache, ref #90. I do think that a note in the readme would help saving some more peoples headache.
