### PR TITLE
preserve file timestamp attributes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,12 @@ module.exports = function(grunt) {
           }
         },
         files: [{ expand: true, cwd: 'test/fixtures', src: ['test2.js', 'beep.wav'], dest: 'tmp/process/' }]
+      },
+      timestamp: {
+        files: [
+            {expand: true, cwd: 'test/fixtures/time_folder/', src: ['**'], dest: 'tmp/copy_test_timestamp/'},
+            {src: 'test/fixtures/time_folder/test.js', dest:'tmp/copy_test_timestamp/test1.js'}
+        ]
       }
     },
 

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -63,5 +63,16 @@ exports.copy = {
     test.notEqual(fs.lstatSync('tmp/process/test2.js').size, fs.lstatSync('test/fixtures/test2.js').size);
 
     test.done();
+  },
+  timestamp: function(test) {
+    'use strict';
+
+    test.expect(3);
+
+    test.equal(fs.lstatSync('tmp/copy_test_timestamp/sub_folder').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/sub_folder').mtime.getTime());
+    test.equal(fs.lstatSync('tmp/copy_test_timestamp/test.js').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/test.js').mtime.getTime());
+    test.notEqual(fs.lstatSync('tmp/copy_test_timestamp/test1.js').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/test.js').mtime.getTime());
+
+    test.done();
   }
 };

--- a/test/expected/copy_test_mix/time_folder/sub_folder/sub_sub_folder/test.js
+++ b/test/expected/copy_test_mix/time_folder/sub_folder/sub_sub_folder/test.js
@@ -1,0 +1,1 @@
+$(document).ready(function(){});

--- a/test/expected/copy_test_mix/time_folder/test.js
+++ b/test/expected/copy_test_mix/time_folder/test.js
@@ -1,0 +1,1 @@
+$(document).ready(function(){});

--- a/test/fixtures/time_folder/sub_folder/sub_sub_folder/test.js
+++ b/test/fixtures/time_folder/sub_folder/sub_sub_folder/test.js
@@ -1,0 +1,1 @@
+$(document).ready(function(){});

--- a/test/fixtures/time_folder/test.js
+++ b/test/fixtures/time_folder/test.js
@@ -1,0 +1,1 @@
+$(document).ready(function(){});


### PR DESCRIPTION
As discussed in #186
Preserve the timestamp attributes  when copy files or directories.
Only when src file and dest file with the same name, the attributes are preserved.

cc @sindresorhus @shama 
