### PR TITLE
fix(log): return singular if only one directory

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
     }
 
     if (tally.dirs) {
-      grunt.log.write('Created ' + chalk.cyan(tally.dirs.toString()) + ' directories');
+      grunt.log.write('Created ' + chalk.cyan(tally.dirs.toString()) + (tally.dirs === 1 ? ' directory' : ' directories'));
     }
 
     if (tally.files) {


### PR DESCRIPTION
If there is only one directory the output should be 'copied 1 directory'
