### PR TITLE
Options.mode to set mode on copied directories

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,20 @@ module.exports = function(grunt) {
         src: ['test/fixtures/test2.js'],
         dest: 'tmp/mode.js'
       },
+
+      modeDir: {
+        options: {
+          mode: '0777'
+        },
+        files: [
+          {
+            expand: true,
+            cwd: 'test/fixtures/',
+            src: ['time_folder/**'],
+            dest: 'tmp/copy_test_modeDir/'}
+        ]
+      },
+
       process: {
         options: {
           noProcess: ['test/fixtures/beep.wav'],
@@ -81,6 +95,7 @@ module.exports = function(grunt) {
         },
         files: [{ expand: true, cwd: 'test/fixtures', src: ['test2.js', 'beep.wav'], dest: 'tmp/process/' }]
       },
+
       timestamp: {
         options: {
             process: function (content, srcpath) {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-copy v0.7.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-copy.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-copy)
+# grunt-contrib-copy v0.7.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-copy.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-copy)
 
 > Copy files and folders.
 
@@ -50,13 +50,15 @@ Default: `grunt.file.defaultEncoding`
 The file encoding to copy files with.
 
 #### mode
-Type: `Boolean` or `Number`  
+Type: `Boolean` or `String`  
 Default: `false`
 
-Whether to copy or set the existing file permissions. Set to `true` to copy the existing file permissions. Or set to the mode, i.e.: `0644`, that copied files will be set to.
+Whether to copy or set the destination file and directory permissions.
+Set to `true` to copy the existing file and directories permissions.
+Or set to the mode, i.e.: `0644`, that copied files will be set to.
 
 #### timestamp
-Type: `Boolean`
+Type: `Boolean`  
 Default: `false`
 
 Whether to preserve the timestamp attributes(`atime` and `mtime`) when copying files. Set to `true` to preserve files timestamp. But timestamp will *not* be preserved when the file contents or name are changed during copying.
@@ -237,4 +239,4 @@ Aborted due to warnings.
 
 Task submitted by [Chris Talkington](http://christalkington.com/)
 
-*This file was generated on Wed Oct 15 2014 09:29:35.*
+*This file was generated on Thu Nov 27 2014 00:17:14.*

--- a/docs/copy-options.md
+++ b/docs/copy-options.md
@@ -21,10 +21,12 @@ Default: `grunt.file.defaultEncoding`
 The file encoding to copy files with.
 
 ## mode
-Type: `Boolean` or `Number`  
+Type: `Boolean` or `String`  
 Default: `false`
 
-Whether to copy or set the existing file permissions. Set to `true` to copy the existing file permissions. Or set to the mode, i.e.: `0644`, that copied files will be set to.
+Whether to copy or set the destination file and directory permissions.
+Set to `true` to copy the existing file and directories permissions.
+Or set to the mode, i.e.: `0644`, that copied files will be set to.
 
 ## timestamp
 Type: `Boolean`  

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -53,6 +53,9 @@ module.exports = function(grunt) {
         if (grunt.file.isDir(src)) {
           grunt.verbose.writeln('Creating ' + chalk.cyan(dest));
           grunt.file.mkdir(dest);
+          if (options.mode !== false) {
+            fs.chmodSync(dest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
+          }
 
           if (options.timestamp) {
             dirs[dest] = src;

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -55,6 +55,15 @@ exports.copy = {
 
     test.done();
   },
+
+  modeDir: function(test) {
+    'use strict';
+    test.expect(2);
+    test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder').mode.toString(8).slice(-3), '777');
+    test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder/sub_folder').mode.toString(8).slice(-3), '777');
+    test.done();
+  },
+
   process: function(test) {
     'use strict';
 


### PR DESCRIPTION
Currently the mode option only sets mode on files. Directories are left with default rights regardless of the parameter. It is an issue when copying folder hierarchies with varying rights.

I changed the code so that `options.mode` also impacts destination directories, with same rules (`true` means copy source rights, `0644` means set to specified rights)
