### PR TITLE
Improve file comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "~0.5.1"
+    "chalk": "~0.5.1",
+    "file-sync-cmp": "~0.1.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.10.0",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
   var fs = require('fs');
   var chalk = require('chalk');
   var crypto = require('crypto');
+  var fileSyncCmp = require('file-sync-cmp');
 
   grunt.registerMultiTask('copy', 'Copy files.', function() {
 
@@ -109,27 +110,13 @@ module.exports = function(grunt) {
     }
   };
 
-  var equalFiles = function(pathA, pathB) {
-    var bufA = fs.readFileSync(pathA);
-    var bufB = fs.readFileSync(pathB);
-    if (bufA.length !== bufB.length) {
-      return false;
-    }
-    for (var i = 0; i < bufA.length; i++) {
-      if (bufA[i] !== bufB[i]) {
-        return false;
-      }
-    }
-    return true;
-  };
-
   var syncTimestamp = function (src, dest) {
     var stat = fs.lstatSync(src);
     if (path.basename(src) !== path.basename(dest)) {
       return;
     }
 
-    if (stat.isFile() && !equalFiles(src, dest)) {
+    if (stat.isFile() && !fileSyncCmp.equalFiles(src, dest)) {
       return;
     }
 


### PR DESCRIPTION
I noticed that the `syncTimestamp` function was using

``` javascript
md5(src) !== md5(dest)
```

to compare the content of two files. This is wasting CPU cycles and uses more memory than necessary since the entire file is read into memory. I replaced it with a function that compared the two files in a chunked fashion.
