### PR TITLE
Enable override of copyOptions per file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,6 +96,27 @@ module.exports = function(grunt) {
         files: [{ expand: true, cwd: 'test/fixtures', src: ['test2.js', 'beep.wav'], dest: 'tmp/process/' }]
       },
 
+      nestedOptions : {
+        options: {
+          process: function(content, srcpath) {
+              return content + '/* comment */';
+          }
+        },
+        files: [
+          {  src: 'test/fixtures/test2.js', dest: 'tmp/copy_test_nestedOptions/output_one.js' },
+          {
+            options: {
+              process: function(content, srcpath) {
+                return content + '/* a custom comment */';
+              }
+            },
+            src: 'test/fixtures/test2.js',
+            dest: 'tmp/copy_test_nestedOptions/output_two.js'
+          },
+          {  src: 'test/fixtures/test2.js', dest: 'tmp/copy_test_nestedOptions/output_three.js' }
+        ]
+      },
+
       timestamp: {
         options: {
             process: function (content, srcpath) {

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -24,20 +24,14 @@ module.exports = function(grunt) {
       processContent: false,
       processContentExclude: [],
       timestamp: false,
-      mode: false,
+      mode: false
     });
-
-    var copyOptions = {
-      encoding: options.encoding,
-      process: options.process || options.processContent,
-      noProcess: options.noProcess || options.processContentExclude,
-    };
 
     var isExpandedPair;
     var dirs = {};
     var tally = {
       dirs: 0,
-      files: 0,
+      files: 0
     };
 
     this.files.forEach(function(filePair) {
@@ -66,6 +60,13 @@ module.exports = function(grunt) {
           tally.dirs++;
         } else {
           grunt.verbose.writeln('Copying ' + chalk.cyan(src) + ' -> ' + chalk.cyan(dest));
+
+          var filepairOptions = filePair.options || {};
+          var copyOptions = {
+              encoding: filepairOptions.encoding || options.encoding,
+              process: filepairOptions.process || filepairOptions.processContent || options.process || options.processContent,
+              noProcess: filepairOptions.noProcess || filepairOptions.processContentExclude || options.noProcess || options.processContentExclude
+          };
           grunt.file.copy(src, dest, copyOptions);
           syncTimestamp(src, dest);
           if (options.mode !== false) {

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -59,8 +59,10 @@ exports.copy = {
   modeDir: function(test) {
     'use strict';
     test.expect(2);
+
     test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder').mode.toString(8).slice(-3), '777');
     test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder/sub_folder').mode.toString(8).slice(-3), '777');
+
     test.done();
   },
 
@@ -73,6 +75,27 @@ exports.copy = {
 
     test.done();
   },
+
+  nestedOptions: function(test) {
+    'use strict';
+
+    test.expect(3);
+
+    var actual = grunt.file.read('tmp/copy_test_nestedOptions/output_one.js');
+    var expected = grunt.file.read('test/expected/copy_test_nestedOptions/output_one.js');
+    test.equal(expected, actual, 'should use the toplevel options for the first file');
+
+    actual = grunt.file.read('tmp/copy_test_nestedOptions/output_two.js');
+    expected = grunt.file.read('test/expected/copy_test_nestedOptions/output_two.js');
+    test.equal(expected, actual, 'should use its own options for the second file');
+
+    actual = grunt.file.read('tmp/copy_test_nestedOptions/output_three.js');
+    expected = grunt.file.read('test/expected/copy_test_nestedOptions/output_three.js');
+    test.equal(expected, actual, 'should use the toplevel options for the third file');
+
+    test.done();
+  },
+
   timestamp: function(test) {
     'use strict';
 

--- a/test/expected/copy_test_nestedOptions/output_one.js
+++ b/test/expected/copy_test_nestedOptions/output_one.js
@@ -1,0 +1,1 @@
+console.log('hello');/* comment */

--- a/test/expected/copy_test_nestedOptions/output_three.js
+++ b/test/expected/copy_test_nestedOptions/output_three.js
@@ -1,0 +1,1 @@
+console.log('hello');/* comment */

--- a/test/expected/copy_test_nestedOptions/output_two.js
+++ b/test/expected/copy_test_nestedOptions/output_two.js
@@ -1,0 +1,1 @@
+console.log('hello');/* a custom comment */


### PR DESCRIPTION
Currently when we process multiple files we can only set copy options which are used for each file. There is no option for overriding the copy option for one of the action. There are scenarios in which this is useful behavior e.g. copying a single file to multiple files but with changed content or copying a single file to different encodings.

This pull request gives the user the ability to override the options on a lower level. If not specified on the lower level the behavior remains unchanged.  

Fixes gruntjs/grunt-contrib-copy#140
