### PR TITLE
Fix for expand-less copies with multiple files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,12 @@ module.exports = function(grunt) {
         ]
       },
 
+      noexpandWild: {
+        files: [
+          {src: 'test/fixtures/*.js', dest: 'tmp/copy_test_noexpandWild/'}
+        ]
+      },
+
       flatten: {
         files: [
           {expand: true, flatten: true, filter: 'isFile', src: ['test/fixtures/**', '!**/*.wav'], dest: 'tmp/copy_test_flatten/'}

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -41,12 +41,11 @@ module.exports = function(grunt) {
     };
 
     this.files.forEach(function(filePair) {
-      var dest = filePair.dest;
       isExpandedPair = filePair.orig.expand || false;
 
       filePair.src.forEach(function(src) {
         src = unixifyPath(src);
-        dest = unixifyPath(dest);
+        var dest = unixifyPath(filePair.dest);
 
         if (detectDestType(dest) === 'directory') {
           dest = (isExpandedPair) ? dest : path.join(dest, src);

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -22,6 +22,20 @@ exports.copy = {
     test.done();
   },
 
+  noexpandWild: function(test) {
+    'use strict';
+
+    test.expect(3);
+
+    ['/', '/test/', '/test/fixtures/'].forEach(function(subpath, i) {
+      var actual = fs.readdirSync('tmp/copy_test_noexpandWild' + subpath).sort();
+      var expected = fs.readdirSync('test/expected/copy_test_noexpandWild' + subpath).sort();
+      test.deepEqual(expected, actual, 'should copy file structure at level ' + i);
+    });
+
+    test.done();
+  },
+
   flatten: function(test) {
     'use strict';
 

--- a/test/expected/copy_test_noexpandWild/test/fixtures/test.js
+++ b/test/expected/copy_test_noexpandWild/test/fixtures/test.js
@@ -1,0 +1,1 @@
+$(document).ready(function(){});

--- a/test/expected/copy_test_noexpandWild/test/fixtures/test2.js
+++ b/test/expected/copy_test_noexpandWild/test/fixtures/test2.js
@@ -1,0 +1,1 @@
+console.log('hello');


### PR DESCRIPTION
This is an attempt to fix #220 with a test that fails against the current master.

Basically, it looks like if `dest` is not freshly-created for each `src` path for a target that does not use `expand`, the return value of `path.join(dest, src)` for the *first* `src` ends up persisting for *every following* `src` (and you only end up with a single file in the destination directory).

If run without the change, the test will fail:

    >> copy - noexpandWild
    >> Message: should copy file structure at level 2
    >> Error: [ 'test.js', 'test2.js' ] deepEqual [ 'test.js' ]

Thanks for the project. Cheers!