### PR TITLE
Fix copying multiple files without expand flag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,12 @@ module.exports = function(grunt) {
         ]
       },
 
+      multiple: {
+        files: [
+          {src: ['test/fixtures/test.js', 'test/fixtures/test2.js'], dest: 'tmp/copy_test_multiple/'}
+        ]
+      },
+
       mode: {
         options: {
           mode: '0444'

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -41,35 +41,35 @@ module.exports = function(grunt) {
     };
 
     this.files.forEach(function(filePair) {
-      var dest = filePair.dest;
+      var dest = unixifyPath(filePair.dest);
       isExpandedPair = filePair.orig.expand || false;
 
       filePair.src.forEach(function(src) {
         src = unixifyPath(src);
-        dest = unixifyPath(dest);
+        var localDest = dest;
 
-        if (detectDestType(dest) === 'directory') {
-          dest = (isExpandedPair) ? dest : path.join(dest, src);
+        if (detectDestType(localDest) === 'directory') {
+          localDest = (isExpandedPair) ? localDest : path.join(localDest, src);
         }
 
         if (grunt.file.isDir(src)) {
-          grunt.verbose.writeln('Creating ' + chalk.cyan(dest));
-          grunt.file.mkdir(dest);
+          grunt.verbose.writeln('Creating ' + chalk.cyan(localDest));
+          grunt.file.mkdir(localDest);
           if (options.mode !== false) {
-            fs.chmodSync(dest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
+            fs.chmodSync(localDest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
           }
 
           if (options.timestamp) {
-            dirs[dest] = src;
+            dirs[localDest] = src;
           }
 
           tally.dirs++;
         } else {
-          grunt.verbose.writeln('Copying ' + chalk.cyan(src) + ' -> ' + chalk.cyan(dest));
-          grunt.file.copy(src, dest, copyOptions);
-          syncTimestamp(src, dest);
+          grunt.verbose.writeln('Copying ' + chalk.cyan(src) + ' -> ' + chalk.cyan(localDest));
+          grunt.file.copy(src, localDest, copyOptions);
+          syncTimestamp(src, localDest);
           if (options.mode !== false) {
-            fs.chmodSync(dest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
+            fs.chmodSync(localDest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
           }
           tally.files++;
         }

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -46,6 +46,22 @@ exports.copy = {
     test.done();
   },
 
+  multiple: function(test) {
+    'use strict';
+
+    test.expect(2);
+
+    var actual = grunt.file.read('tmp/copy_test_multiple/test/fixtures/test.js');
+    var expected = grunt.file.read('test/fixtures/test.js');
+    test.equal(expected, actual);
+
+    actual = grunt.file.read('tmp/copy_test_multiple/test/fixtures/test2.js');
+    expected = grunt.file.read('test/fixtures/test2.js');
+    test.equal(expected, actual);
+
+    test.done();
+  },
+
   mode: function(test) {
     'use strict';
 


### PR DESCRIPTION
This PR fixes an issue introduced in a15feecc. It causes files not being copied correctly when selecting multiple sources without the `expand` flag:

```js
files: [
  {src: ['test/fixtures/test.js', 'test/fixtures/test2.js'], dest: 'tmp/copy_test_multiple/'}
]
```

Output of grunt before the PR:

```
Copying test/fixtures/test.js -> tmp/copy_test_multiple/test/fixtures/test.js
Reading test/fixtures/test.js...OK
Writing tmp/copy_test_multiple/test/fixtures/test.js...OK
Copying test/fixtures/test2.js -> tmp/copy_test_multiple/test/fixtures/test.js
Reading test/fixtures/test2.js...OK
Writing tmp/copy_test_multiple/test/fixtures/test.js...OK
```