### PR TITLE
Get src

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -39,12 +39,18 @@ module.exports = function(grunt) {
       dirs: 0,
       files: 0,
     };
+    var sources;
 
     this.files.forEach(function(filePair) {
       var dest = filePair.dest;
       isExpandedPair = filePair.orig.expand || false;
+      if( filePair.getSrc && typeof filePair.getSrc === 'undefined' ) {
+        sources = filePair.getSrc();
+      }else{
+        sources = filePair.src;
+      }
 
-      filePair.src.forEach(function(src) {
+      sources.forEach(function(src) {
         src = unixifyPath(src);
         dest = unixifyPath(dest);
 

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
     this.files.forEach(function(filePair) {
       var dest = filePair.dest;
       isExpandedPair = filePair.orig.expand || false;
-      if( filePair.getSrc && typeof filePair.getSrc === 'undefined' ) {
+      if( filePair.getSrc && typeof filePair.getSrc === 'function' ) {
         sources = filePair.getSrc();
       }else{
         sources = filePair.src;


### PR DESCRIPTION
Hello. I have just come around with a solution for generating dynamic filenames. it is useful whenever you have to choose between copy a minified file or a not minified file to copy only one of them.

Unluckily, you have to modify the way you were passing the attributes:
* **src** --> Must be a string or a strings array with the name of an existing directory, even if you are not using it.
* **dest** --> You have to append the name of the copied file to the dest attribute.
* You have to prepend the original dest set in the main attributes to your generated src names

![attributes](https://cloud.githubusercontent.com/assets/9370052/8546798/b529f31c-24ba-11e5-98d2-53f5cfd5d755.PNG)
![getsrcfunction](https://cloud.githubusercontent.com/assets/9370052/8546800/b7d4e23e-24ba-11e5-8b4d-4971b34c8836.PNG)
