### PR TITLE
Fix error when process function returns false

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -67,7 +67,9 @@ module.exports = function(grunt) {
         } else {
           grunt.verbose.writeln('Copying ' + chalk.cyan(src) + ' -> ' + chalk.cyan(dest));
           grunt.file.copy(src, dest, copyOptions);
-          syncTimestamp(src, dest);
+          if (fs.existsSync(dest)) {
+              syncTimestamp(src, dest);
+          }
           if (options.mode !== false) {
             fs.chmodSync(dest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
           }


### PR DESCRIPTION
Check if the destination file exists before calling timestamp sync