### PR TITLE
Add mtimeUpdate parameter

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -25,6 +25,7 @@ module.exports = function(grunt) {
       processContentExclude: [],
       timestamp: false,
       mode: false,
+      mtimeUpdate: false
     });
 
     var copyOptions = {
@@ -111,7 +112,7 @@ module.exports = function(grunt) {
     }
   };
 
-  var syncTimestamp = function (src, dest) {
+  var syncTimestamp = function (src, dest, mtimeUpdate) {
     var stat = fs.lstatSync(src);
     if (path.basename(src) !== path.basename(dest)) {
       return;

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
         } else {
           grunt.verbose.writeln('Copying ' + chalk.cyan(src) + ' -> ' + chalk.cyan(dest));
           grunt.file.copy(src, dest, copyOptions);
-          syncTimestamp(src, dest);
+          syncTimestamp(src, dest, options.mtimeUpdate);
           if (options.mode !== false) {
             fs.chmodSync(dest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
           }
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
       Object.keys(dirs).sort(function (a, b) {
         return b.length - a.length;
       }).forEach(function (dest) {
-        syncTimestamp(dirs[dest], dest);
+        syncTimestamp(dirs[dest], dest, options.mtimeUpdate);
       });
     }
 
@@ -121,6 +121,8 @@ module.exports = function(grunt) {
       return;
     }
 
-    fs.utimesSync(dest, stat.atime, stat.mtime);
+    var mtime = mtimeUpdate ? new Date() : stat.mtime;
+
+    fs.utimesSync(dest, stat.atime, mtime);
   };
 };


### PR DESCRIPTION
Currently, when copying a file from src to dest with grunt-contrib-copy the last modified time of the file is not updated.

It would be nice to have the ability to force updating this value as to play nice with grunt:newer. See: https://github.com/tschaub/grunt-newer/issues/84

This PR introduces a new option to, `mtimeUpdate` which, if set to true, will force the copied file's mtime to be set to the current time.
