### PR TITLE
Specify expand: true for single file tree example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ $ tree -I node_modules
 ```js
 copy: {
   main: {
+    expand: true,
     src: 'src/*',
     dest: 'dest/',
   },
@@ -241,4 +242,4 @@ Aborted due to warnings.
 
 Task submitted by [Chris Talkington](http://christalkington.com/)
 
-*This file was generated on Mon Feb 01 2016 11:25:13.*
+*This file was generated on Tue Feb 23 2016 15:40:33.*

--- a/docs/copy-examples.md
+++ b/docs/copy-examples.md
@@ -39,6 +39,7 @@ $ tree -I node_modules
 ```js
 copy: {
   main: {
+    expand: true,
     src: 'src/*',
     dest: 'dest/',
   },


### PR DESCRIPTION
In order for the `Copy a single file tree` example to work as expected, I added `expand: true` to it. Otherwise it won't add the directory.

Would it also be better to use `**` so the file `b` gets included in the copy?