### PR TITLE
fix syncing utimes if copied files

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
   var fs = require('fs');
   var chalk = require('chalk');
   var fileSyncCmp = require('file-sync-cmp');
+  var isWindows = /^win/.test(process.platform);
 
   grunt.registerMultiTask('copy', 'Copy files.', function() {
 
@@ -102,7 +103,7 @@ module.exports = function(grunt) {
   };
 
   var unixifyPath = function(filepath) {
-    if (process.platform === 'win32') {
+    if (isWindows) {
       return filepath.replace(/\\/g, '/');
     } else {
       return filepath;
@@ -119,6 +120,8 @@ module.exports = function(grunt) {
       return;
     }
 
-    fs.utimesSync(dest, stat.atime, stat.mtime);
+    var fd = fs.openSync(dest, isWindows ? 'r+' : 'r');
+    fs.futimesSync(fd, stat.atime, stat.mtime);
+    fs.closeSync(fd);
   };
 };

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
   var fs = require('fs');
   var chalk = require('chalk');
   var fileSyncCmp = require('file-sync-cmp');
-  var isWindows = /^win/.test(process.platform);
+  var isWindows = process.platform === 'win32';
 
   grunt.registerMultiTask('copy', 'Copy files.', function() {
 

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -2,7 +2,7 @@
 
 var grunt = require('grunt');
 var fs = require('fs');
-var isWindows = /^win/.test(process.platform);
+var isWindows = process.platform === 'win32';
 
 exports.copy = {
   main: function(test) {
@@ -80,14 +80,22 @@ exports.copy = {
     test.done();
   },
 
-  timestamp: function(test) {
-    test.expect(4);
-
+  timestamp_equal: function(test) {
+    if (isWindows) {
+        // Known Issue: this test will not pass on Windows due to bug in nodejs (https://github.com/nodejs/node/issues/2069)
+        test.done();
+        return;
+    }
+    test.expect(2);
     test.equal(fs.lstatSync('tmp/copy_test_timestamp/sub_folder').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/sub_folder').mtime.getTime());
     test.equal(fs.lstatSync('tmp/copy_test_timestamp/test.js').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/test.js').mtime.getTime());
+    test.done();
+  },
+
+  timestamp_changed: function(test) {
+    test.expect(2);
     test.notEqual(fs.lstatSync('tmp/copy_test_timestamp/test1.js').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/test.js').mtime.getTime());
     test.notEqual(fs.lstatSync('tmp/copy_test_timestamp/test_process.js').mtime.getTime(), fs.lstatSync('test/fixtures/time_folder/test_process.js').mtime.getTime());
-
     test.done();
   }
 };

--- a/test/copy_test.js
+++ b/test/copy_test.js
@@ -2,6 +2,7 @@
 
 var grunt = require('grunt');
 var fs = require('fs');
+var isWindows = /^win/.test(process.platform);
 
 exports.copy = {
   main: function(test) {
@@ -64,8 +65,10 @@ exports.copy = {
 
   modeDir: function(test) {
     test.expect(2);
-    test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder').mode.toString(8).slice(-3), '777');
-    test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder/sub_folder').mode.toString(8).slice(-3), '777');
+    // on windows DIRs do not have 'executable' flag, see: https://github.com/nodejs/node/blob/master/deps/uv/src/win/fs.c#L1064
+    var expectedMode = isWindows ? '666' : '777';
+    test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder').mode.toString(8).slice(-3), expectedMode);
+    test.equal(fs.lstatSync('tmp/copy_test_modeDir/time_folder/sub_folder').mode.toString(8).slice(-3), expectedMode);
     test.done();
   },
 


### PR DESCRIPTION
`fs.utimesSync` saves times with one second precision, while `fs.statSync` gives us microsecond precision.

This makes `utimes` not synchronized on filesystems with sub-second `atime`/`ctime`/`mtime` precision.

Upgraded to use newer `fs.futimesSync` interface providing correct precision.

Fixes #257.