### PR TITLE
stop testing node 4, 6, start testing 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
   - "8"
+  - "12"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
AFAIK the current version no longer works in node 4 and 6 because some of the dependencies are using JS features not found in before 8